### PR TITLE
Fix/warning wallet multi button warning

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,17 @@
 import { useWallet } from '@solana/wallet-adapter-react';
-import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
+import dynamic from 'next/dynamic';
 import { useEffect, useState } from 'react';
 
 import CreateProduct from '../components/CreateProduct';
 import HeadComponent from '../components/Head';
 import Product from '../components/Product';
+
+// 参照: https://github.com/solana-labs/wallet-adapter/issues/648
+const WalletMultiButtonDynamic = dynamic(
+  async () =>
+    (await import('@solana/wallet-adapter-react-ui')).WalletMultiButton,
+  { ssr: false },
+);
 
 // 定数を宣言します。
 const TWITTER_HANDLE = 'kii_bmi_N_perm';
@@ -36,7 +43,7 @@ const App = () => {
         alt="anya"
       />
       <div className="button-container">
-        <WalletMultiButton className="cta-button connect-wallet-button" />
+        <WalletMultiButtonDynamic className="cta-button connect-wallet-button" />
       </div>
     </div>
   );


### PR DESCRIPTION
## 変更内容
ウォレットの接続で使用する`WalletMultiButton`コンポーネントをクライアントサイドのみでレンダリングするように修正

## 背景
warningの発生を確認したため

![Screen Shot 2023-06-01 at 0 27 17](https://github.com/unchain-tech/Solana-Online-Store/assets/60546319/fc1970fd-d365-43a1-9c26-6f9fa85ed7a4)

## 備考
### 参照
- https://github.com/solana-labs/wallet-adapter/issues/648
- https://github.com/solana-labs/wallet-adapter/commit/70fd5aac6eaf9584b0e3034685236a850e3488e4

### その他
コンテンツへの反映は[こちらのPR](https://github.com/unchain-tech/UNCHAIN-projects/pull/405)で出しています。